### PR TITLE
Fix compile errors in MT4/MT5 EA symbol handling and trade checks

### DIFF
--- a/experts/DirectionalPullbackEA.mq4
+++ b/experts/DirectionalPullbackEA.mq4
@@ -1,0 +1,356 @@
+#property strict
+#property description "Directional Pullback EA (MT4): discretionary direction + M5 pullback execution"
+
+extern int    MagicNumber                = 52001;
+extern double BaseRiskPercent            = 1.0;
+extern int    DirectionMode              = 0;      // 0=LongOnly,1=ShortOnly,2=Both
+extern int    FastEMAPeriod              = 20;
+extern int    SlowEMAPeriod              = 50;
+extern int    RSIPeriod                  = 14;
+extern double RSIZoneLow                 = 40.0;
+extern double RSIZoneHigh                = 50.0;
+extern int    BreakoutLookbackBars       = 20;
+extern int    FractalLeft                = 2;
+extern int    FractalRight               = 2;
+extern int    StructureLookbackBars      = 200;
+extern int    SlBufferPoints             = 2;
+extern int    MaxSpreadPoints            = 120;
+extern int    SessionStartHour           = 0;      // server time hour
+extern int    SessionEndHour             = 23;     // server time hour
+extern string AllowedSymbolsCSV          = "XAUUSD,EURUSD,GBPUSD,AUDUSD,US100,USOIL,BTCUSD";
+extern double DDLevel1Pct                = 5.0;
+extern double DDLevel2Pct                = 10.0;
+extern double DDLevel3Pct                = 15.0;
+extern double DDCoeff1                   = 1.0;
+extern double DDCoeff2                   = 0.7;
+extern double DDCoeff3                   = 0.5;
+extern double DDCoeff4                   = 0.2;
+
+string PEAK_BALANCE_KEY;
+datetime g_lastBarTime = 0;
+
+
+string ToUpperCopy(string v)
+{
+   StringToUpper(v);
+   return v;
+}
+
+string TrimCopy(string v)
+{
+   while(StringLen(v) > 0 && StringGetCharacter(v, 0) <= 32)
+      v = StringSubstr(v, 1);
+   while(StringLen(v) > 0 && StringGetCharacter(v, StringLen(v)-1) <= 32)
+      v = StringSubstr(v, 0, StringLen(v)-1);
+   return v;
+}
+
+
+bool IsNewBar()
+{
+   datetime t = iTime(Symbol(), PERIOD_M5, 0);
+   if(t != g_lastBarTime)
+   {
+      g_lastBarTime = t;
+      return true;
+   }
+   return false;
+}
+
+bool IsAllowedSymbol()
+{
+   string s = ToUpperCopy(Symbol());
+   string csv = ToUpperCopy(AllowedSymbolsCSV);
+   string parts[];
+   int n = StringSplit(csv, ',', parts);
+   for(int i=0;i<n;i++)
+   {
+      string p = parts[i];
+      p = TrimCopy(p);
+      if(s == p) return true;
+   }
+   return false;
+}
+
+bool InSession()
+{
+   if(SessionStartHour == SessionEndHour) return true;
+   int h = TimeHour(TimeCurrent());
+   if(SessionStartHour < SessionEndHour)
+      return (h >= SessionStartHour && h < SessionEndHour);
+   return (h >= SessionStartHour || h < SessionEndHour);
+}
+
+bool HasOpenPositionForSymbol()
+{
+   for(int i=OrdersTotal()-1;i>=0;i--)
+   {
+      if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
+      if(OrderSymbol()==Symbol() && OrderMagicNumber()==MagicNumber && (OrderType()==OP_BUY || OrderType()==OP_SELL))
+         return true;
+   }
+   return false;
+}
+
+void UpdatePeakBalance()
+{
+   double bal = AccountBalance();
+   if(!GlobalVariableCheck(PEAK_BALANCE_KEY))
+   {
+      GlobalVariableSet(PEAK_BALANCE_KEY, bal);
+      return;
+   }
+   double peak = GlobalVariableGet(PEAK_BALANCE_KEY);
+   if(bal > peak)
+      GlobalVariableSet(PEAK_BALANCE_KEY, bal);
+}
+
+double GetDDCoeff()
+{
+   double bal = AccountBalance();
+   double peak = GlobalVariableCheck(PEAK_BALANCE_KEY) ? GlobalVariableGet(PEAK_BALANCE_KEY) : bal;
+   if(peak <= 0.0) return DDCoeff1;
+   double ddPct = (peak - bal) / peak * 100.0;
+   if(ddPct < DDLevel1Pct) return DDCoeff1;
+   if(ddPct < DDLevel2Pct) return DDCoeff2;
+   if(ddPct < DDLevel3Pct) return DDCoeff3;
+   return DDCoeff4;
+}
+
+bool TouchesEMABand(int shift, double emaFast, double emaSlow)
+{
+   double top = MathMax(emaFast, emaSlow);
+   double bot = MathMin(emaFast, emaSlow);
+   double hi = iHigh(Symbol(), PERIOD_M5, shift);
+   double lo = iLow(Symbol(), PERIOD_M5, shift);
+   return (lo <= top && hi >= bot);
+}
+
+bool IsFractalLow(int shift)
+{
+   if(shift <= FractalRight) return false;
+   double center = iLow(Symbol(), PERIOD_M5, shift);
+   for(int i=1;i<=FractalLeft;i++) if(iLow(Symbol(), PERIOD_M5, shift+i) <= center) return false;
+   for(int j=1;j<=FractalRight;j++) if(iLow(Symbol(), PERIOD_M5, shift-j) <= center) return false;
+   return true;
+}
+
+bool IsFractalHigh(int shift)
+{
+   if(shift <= FractalRight) return false;
+   double center = iHigh(Symbol(), PERIOD_M5, shift);
+   for(int i=1;i<=FractalLeft;i++) if(iHigh(Symbol(), PERIOD_M5, shift+i) >= center) return false;
+   for(int j=1;j<=FractalRight;j++) if(iHigh(Symbol(), PERIOD_M5, shift-j) >= center) return false;
+   return true;
+}
+
+bool FindLatestFractalLow(double &price)
+{
+   int start = FractalRight + 1;
+   int end = MathMin(StructureLookbackBars, Bars-2-FractalLeft);
+   for(int s=start; s<=end; s++)
+   {
+      if(IsFractalLow(s))
+      {
+         price = iLow(Symbol(), PERIOD_M5, s);
+         return true;
+      }
+   }
+   return false;
+}
+
+bool FindLatestFractalHigh(double &price)
+{
+   int start = FractalRight + 1;
+   int end = MathMin(StructureLookbackBars, Bars-2-FractalLeft);
+   for(int s=start; s<=end; s++)
+   {
+      if(IsFractalHigh(s))
+      {
+         price = iHigh(Symbol(), PERIOD_M5, s);
+         return true;
+      }
+   }
+   return false;
+}
+
+double HighestHigh(int fromShift, int count)
+{
+   double v = -DBL_MAX;
+   for(int i=fromShift; i<fromShift+count; i++) v = MathMax(v, iHigh(Symbol(), PERIOD_M5, i));
+   return v;
+}
+
+double LowestLow(int fromShift, int count)
+{
+   double v = DBL_MAX;
+   for(int i=fromShift; i<fromShift+count; i++) v = MathMin(v, iLow(Symbol(), PERIOD_M5, i));
+   return v;
+}
+
+double CalcLotByRisk(double slDistancePrice)
+{
+   if(slDistancePrice <= 0.0) return 0.0;
+   double coeff = GetDDCoeff();
+   double effectiveRiskPct = BaseRiskPercent * coeff;
+   double riskMoney = AccountBalance() * effectiveRiskPct / 100.0;
+
+   double tickValue = MarketInfo(Symbol(), MODE_TICKVALUE);
+   double tickSize  = MarketInfo(Symbol(), MODE_TICKSIZE);
+   if(tickSize <= 0.0 || tickValue <= 0.0) return 0.0;
+
+   double points = slDistancePrice / Point;
+   double valuePerPointPerLot = tickValue * (Point / tickSize);
+   double lossPerLot = points * valuePerPointPerLot;
+   if(lossPerLot <= 0.0) return 0.0;
+
+   double lot = riskMoney / lossPerLot;
+   double minLot = MarketInfo(Symbol(), MODE_MINLOT);
+   double maxLot = MarketInfo(Symbol(), MODE_MAXLOT);
+   double step   = MarketInfo(Symbol(), MODE_LOTSTEP);
+
+   lot = MathMax(minLot, MathMin(maxLot, lot));
+   lot = MathFloor(lot/step)*step;
+   return NormalizeDouble(lot, 2);
+}
+
+bool BuySignal()
+{
+   int s = 1;
+   double ema20 = iMA(Symbol(), PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, s);
+   double ema50 = iMA(Symbol(), PERIOD_M5, SlowEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, s);
+   if(!TouchesEMABand(s, ema20, ema50)) return false;
+
+   double rsi1 = iRSI(Symbol(), PERIOD_M5, RSIPeriod, PRICE_CLOSE, s);
+   double rsi2 = iRSI(Symbol(), PERIOD_M5, RSIPeriod, PRICE_CLOSE, s+1);
+   if(!(rsi1 >= RSIZoneLow && rsi1 <= RSIZoneHigh && rsi1 > rsi2)) return false;
+
+   double trigger = HighestHigh(2, BreakoutLookbackBars);
+   double close1 = iClose(Symbol(), PERIOD_M5, s);
+   return (close1 > trigger);
+}
+
+bool SellSignal()
+{
+   int s = 1;
+   double ema20 = iMA(Symbol(), PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, s);
+   double ema50 = iMA(Symbol(), PERIOD_M5, SlowEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, s);
+   if(!TouchesEMABand(s, ema20, ema50)) return false;
+
+   double rsi1 = iRSI(Symbol(), PERIOD_M5, RSIPeriod, PRICE_CLOSE, s);
+   double rsi2 = iRSI(Symbol(), PERIOD_M5, RSIPeriod, PRICE_CLOSE, s+1);
+   if(!(rsi1 >= (100.0-RSIZoneHigh) && rsi1 <= (100.0-RSIZoneLow) && rsi1 < rsi2)) return false;
+
+   double trigger = LowestLow(2, BreakoutLookbackBars);
+   double close1 = iClose(Symbol(), PERIOD_M5, s);
+   return (close1 < trigger);
+}
+
+void ManageOpenPosition()
+{
+   for(int i=OrdersTotal()-1;i>=0;i--)
+   {
+      if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
+      if(OrderSymbol()!=Symbol() || OrderMagicNumber()!=MagicNumber) continue;
+
+      if(OrderType()==OP_BUY)
+      {
+         double ema1 = iMA(Symbol(), PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, 1);
+         double ema2 = iMA(Symbol(), PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, 2);
+         double c1 = iClose(Symbol(), PERIOD_M5, 1), c2 = iClose(Symbol(), PERIOD_M5, 2);
+         if(c1 < ema1 && c2 >= ema2)
+         {
+            if(!OrderClose(OrderTicket(), OrderLots(), Bid, 30, clrRed))
+               Print("OrderClose(BUY) failed. err=", GetLastError());
+            continue;
+         }
+
+         double fract;
+         if(FindLatestFractalLow(fract))
+         {
+            double newSL = fract - SlBufferPoints*Point;
+            if(newSL > OrderStopLoss() && newSL < Bid)
+               if(!OrderModify(OrderTicket(), OrderOpenPrice(), NormalizeDouble(newSL, Digits), 0, 0, clrBlue))
+                  Print("OrderModify(BUY) failed. err=", GetLastError());
+         }
+      }
+      else if(OrderType()==OP_SELL)
+      {
+         double ema1 = iMA(Symbol(), PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, 1);
+         double ema2 = iMA(Symbol(), PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE, 2);
+         double c1 = iClose(Symbol(), PERIOD_M5, 1), c2 = iClose(Symbol(), PERIOD_M5, 2);
+         if(c1 > ema1 && c2 <= ema2)
+         {
+            if(!OrderClose(OrderTicket(), OrderLots(), Ask, 30, clrRed))
+               Print("OrderClose(SELL) failed. err=", GetLastError());
+            continue;
+         }
+
+         double fract;
+         if(FindLatestFractalHigh(fract))
+         {
+            double spreadPts = MarketInfo(Symbol(), MODE_SPREAD);
+            double newSL = fract + (spreadPts + SlBufferPoints)*Point;
+            if((OrderStopLoss()==0.0 || newSL < OrderStopLoss()) && newSL > Ask)
+               if(!OrderModify(OrderTicket(), OrderOpenPrice(), NormalizeDouble(newSL, Digits), 0, 0, clrBlue))
+                  Print("OrderModify(SELL) failed. err=", GetLastError());
+         }
+      }
+   }
+}
+
+int OnInit()
+{
+   PEAK_BALANCE_KEY = "DirectionalPullbackEA_peak_" + IntegerToString(AccountNumber());
+   UpdatePeakBalance();
+   return(INIT_SUCCEEDED);
+}
+
+void OnTick()
+{
+   if(Period() != PERIOD_M5) return;
+   if(!IsAllowedSymbol()) return;
+   if(!InSession()) return;
+   if(MarketInfo(Symbol(), MODE_SPREAD) > MaxSpreadPoints) return;
+
+   UpdatePeakBalance();
+
+   if(IsNewBar()) ManageOpenPosition();
+   if(HasOpenPositionForSymbol()) return;
+
+   int dir = DirectionMode;
+   if(dir==0 || dir==2)
+   {
+      if(BuySignal())
+      {
+         double fract;
+         if(!FindLatestFractalLow(fract)) return;
+         double sl = fract - SlBufferPoints*Point;
+         double entry = Ask;
+         double lot = CalcLotByRisk(entry - sl);
+         if(lot > 0.0 && sl < entry)
+         {
+            int tkBuy = OrderSend(Symbol(), OP_BUY, lot, Ask, 30, NormalizeDouble(sl, Digits), 0, "DirPullbackEA", MagicNumber, 0, clrGreen);
+            if(tkBuy < 0) Print("OrderSend(BUY) failed. err=", GetLastError());
+         }
+      }
+   }
+
+   if(dir==1 || dir==2)
+   {
+      if(SellSignal())
+      {
+         double fract;
+         if(!FindLatestFractalHigh(fract)) return;
+         double spreadPts = MarketInfo(Symbol(), MODE_SPREAD);
+         double sl = fract + (spreadPts + SlBufferPoints)*Point;
+         double entry = Bid;
+         double lot = CalcLotByRisk(sl - entry);
+         if(lot > 0.0 && sl > entry)
+         {
+            int tkSell = OrderSend(Symbol(), OP_SELL, lot, Bid, 30, NormalizeDouble(sl, Digits), 0, "DirPullbackEA", MagicNumber, 0, clrGreen);
+            if(tkSell < 0) Print("OrderSend(SELL) failed. err=", GetLastError());
+         }
+      }
+   }
+}

--- a/experts/DirectionalPullbackEA.mq5
+++ b/experts/DirectionalPullbackEA.mq5
@@ -1,0 +1,372 @@
+#property strict
+#property version   "1.00"
+#property description "Directional Pullback EA (MT5): discretionary direction + M5 pullback execution"
+
+#include <Trade/Trade.mqh>
+CTrade trade;
+
+enum DirectionEnum { LongOnly=0, ShortOnly=1, Both=2 };
+
+input int      MagicNumber                = 52501;
+input double   BaseRiskPercent            = 1.0;
+input DirectionEnum DirectionMode          = LongOnly;
+input int      FastEMAPeriod              = 20;
+input int      SlowEMAPeriod              = 50;
+input int      RSIPeriod                  = 14;
+input double   RSIZoneLow                 = 40.0;
+input double   RSIZoneHigh                = 50.0;
+input int      BreakoutLookbackBars       = 20;
+input int      FractalLeft                = 2;
+input int      FractalRight               = 2;
+input int      StructureLookbackBars      = 200;
+input int      SlBufferPoints             = 2;
+input int      MaxSpreadPoints            = 120;
+input int      SessionStartHour           = 0;
+input int      SessionEndHour             = 23;
+input string   AllowedSymbolsCSV          = "XAUUSD,EURUSD,GBPUSD,AUDUSD,US100,USOIL,BTCUSD";
+input double   DDLevel1Pct                = 5.0;
+input double   DDLevel2Pct                = 10.0;
+input double   DDLevel3Pct                = 15.0;
+input double   DDCoeff1                   = 1.0;
+input double   DDCoeff2                   = 0.7;
+input double   DDCoeff3                   = 0.5;
+input double   DDCoeff4                   = 0.2;
+
+string PEAK_BALANCE_KEY;
+datetime g_lastBarTime = 0;
+
+
+string ToUpperCopy(string v)
+{
+   StringToUpper(v);
+   return v;
+}
+
+string TrimCopy(string v)
+{
+   while(StringLen(v) > 0 && StringGetCharacter(v, 0) <= 32)
+      v = StringSubstr(v, 1);
+   while(StringLen(v) > 0 && StringGetCharacter(v, StringLen(v)-1) <= 32)
+      v = StringSubstr(v, 0, StringLen(v)-1);
+   return v;
+}
+
+int hEMA20, hEMA50, hRSI;
+
+bool IsNewBar()
+{
+   datetime t[];
+   if(CopyTime(_Symbol, PERIOD_M5, 0, 1, t) < 1) return false;
+   if(t[0] != g_lastBarTime)
+   {
+      g_lastBarTime = t[0];
+      return true;
+   }
+   return false;
+}
+
+bool IsAllowedSymbol()
+{
+   string s = ToUpperCopy(_Symbol);
+   string csv = ToUpperCopy(AllowedSymbolsCSV);
+   string parts[];
+   int n = StringSplit(csv, ',', parts);
+   for(int i=0;i<n;i++)
+   {
+      string p = parts[i];
+      p = TrimCopy(p);
+      if(s == p) return true;
+   }
+   return false;
+}
+
+bool InSession()
+{
+   if(SessionStartHour == SessionEndHour) return true;
+   MqlDateTime dt; TimeToStruct(TimeCurrent(), dt);
+   int h = dt.hour;
+   if(SessionStartHour < SessionEndHour) return (h >= SessionStartHour && h < SessionEndHour);
+   return (h >= SessionStartHour || h < SessionEndHour);
+}
+
+void UpdatePeakBalance()
+{
+   double bal = AccountInfoDouble(ACCOUNT_BALANCE);
+   if(!GlobalVariableCheck(PEAK_BALANCE_KEY))
+   {
+      GlobalVariableSet(PEAK_BALANCE_KEY, bal);
+      return;
+   }
+   double peak = GlobalVariableGet(PEAK_BALANCE_KEY);
+   if(bal > peak) GlobalVariableSet(PEAK_BALANCE_KEY, bal);
+}
+
+double GetDDCoeff()
+{
+   double bal = AccountInfoDouble(ACCOUNT_BALANCE);
+   double peak = GlobalVariableCheck(PEAK_BALANCE_KEY) ? GlobalVariableGet(PEAK_BALANCE_KEY) : bal;
+   if(peak <= 0.0) return DDCoeff1;
+   double ddPct = (peak - bal) / peak * 100.0;
+   if(ddPct < DDLevel1Pct) return DDCoeff1;
+   if(ddPct < DDLevel2Pct) return DDCoeff2;
+   if(ddPct < DDLevel3Pct) return DDCoeff3;
+   return DDCoeff4;
+}
+
+bool HasOpenPositionForSymbol()
+{
+   if(!PositionSelect(_Symbol)) return false;
+   if((int)PositionGetInteger(POSITION_MAGIC) != MagicNumber) return false;
+   return true;
+}
+
+bool TouchesEMABand(const MqlRates &bar, double emaFast, double emaSlow)
+{
+   double top = MathMax(emaFast, emaSlow);
+   double bot = MathMin(emaFast, emaSlow);
+   return (bar.low <= top && bar.high >= bot);
+}
+
+bool IsFractalLow(MqlRates &rates[], int idx)
+{
+   double c = rates[idx].low;
+   for(int i=1;i<=FractalLeft;i++) if(rates[idx+i].low <= c) return false;
+   for(int j=1;j<=FractalRight;j++) if(rates[idx-j].low <= c) return false;
+   return true;
+}
+
+bool IsFractalHigh(MqlRates &rates[], int idx)
+{
+   double c = rates[idx].high;
+   for(int i=1;i<=FractalLeft;i++) if(rates[idx+i].high >= c) return false;
+   for(int j=1;j<=FractalRight;j++) if(rates[idx-j].high >= c) return false;
+   return true;
+}
+
+bool FindLatestFractalLow(double &price)
+{
+   MqlRates rates[];
+   int need = MathMax(StructureLookbackBars + FractalLeft + FractalRight + 5, 100);
+   int got = CopyRates(_Symbol, PERIOD_M5, 0, need, rates);
+   if(got <= FractalLeft + FractalRight + 5) return false;
+   ArraySetAsSeries(rates, true);
+
+   for(int idx=FractalRight+1; idx<MathMin(got-FractalLeft, StructureLookbackBars); idx++)
+   {
+      if(IsFractalLow(rates, idx))
+      {
+         price = rates[idx].low;
+         return true;
+      }
+   }
+   return false;
+}
+
+bool FindLatestFractalHigh(double &price)
+{
+   MqlRates rates[];
+   int need = MathMax(StructureLookbackBars + FractalLeft + FractalRight + 5, 100);
+   int got = CopyRates(_Symbol, PERIOD_M5, 0, need, rates);
+   if(got <= FractalLeft + FractalRight + 5) return false;
+   ArraySetAsSeries(rates, true);
+
+   for(int idx=FractalRight+1; idx<MathMin(got-FractalLeft, StructureLookbackBars); idx++)
+   {
+      if(IsFractalHigh(rates, idx))
+      {
+         price = rates[idx].high;
+         return true;
+      }
+   }
+   return false;
+}
+
+double CalcLotByRisk(double slDistancePrice)
+{
+   if(slDistancePrice <= 0.0) return 0.0;
+
+   double coeff = GetDDCoeff();
+   double riskPct = BaseRiskPercent * coeff;
+   double riskMoney = AccountInfoDouble(ACCOUNT_BALANCE) * riskPct / 100.0;
+
+   double tickValue = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
+   double tickSize  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
+   double point     = _Point;
+   if(tickSize <= 0.0 || tickValue <= 0.0) return 0.0;
+
+   double points = slDistancePrice / point;
+   double valuePerPointPerLot = tickValue * (point / tickSize);
+   double lossPerLot = points * valuePerPointPerLot;
+   if(lossPerLot <= 0.0) return 0.0;
+
+   double volMin = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
+   double volMax = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MAX);
+   double volStep= SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_STEP);
+
+   double lot = riskMoney / lossPerLot;
+   lot = MathMax(volMin, MathMin(volMax, lot));
+   lot = MathFloor(lot / volStep) * volStep;
+   return NormalizeDouble(lot, 2);
+}
+
+bool BuySignal()
+{
+   MqlRates bars[];
+   if(CopyRates(_Symbol, PERIOD_M5, 0, BreakoutLookbackBars + 5, bars) < BreakoutLookbackBars + 3) return false;
+   ArraySetAsSeries(bars, true);
+
+   double ema20[3], ema50[3], rsi[4];
+   if(CopyBuffer(hEMA20, 0, 0, 3, ema20) < 3) return false;
+   if(CopyBuffer(hEMA50, 0, 0, 3, ema50) < 3) return false;
+   if(CopyBuffer(hRSI, 0, 0, 4, rsi) < 4) return false;
+   ArraySetAsSeries(ema20, true); ArraySetAsSeries(ema50, true); ArraySetAsSeries(rsi, true);
+
+   if(!TouchesEMABand(bars[1], ema20[1], ema50[1])) return false;
+   if(!(rsi[1] >= RSIZoneLow && rsi[1] <= RSIZoneHigh && rsi[1] > rsi[2])) return false;
+
+   double hh = -DBL_MAX;
+   for(int i=2;i<2+BreakoutLookbackBars;i++) hh = MathMax(hh, bars[i].high);
+   return (bars[1].close > hh);
+}
+
+bool SellSignal()
+{
+   MqlRates bars[];
+   if(CopyRates(_Symbol, PERIOD_M5, 0, BreakoutLookbackBars + 5, bars) < BreakoutLookbackBars + 3) return false;
+   ArraySetAsSeries(bars, true);
+
+   double ema20[3], ema50[3], rsi[4];
+   if(CopyBuffer(hEMA20, 0, 0, 3, ema20) < 3) return false;
+   if(CopyBuffer(hEMA50, 0, 0, 3, ema50) < 3) return false;
+   if(CopyBuffer(hRSI, 0, 0, 4, rsi) < 4) return false;
+   ArraySetAsSeries(ema20, true); ArraySetAsSeries(ema50, true); ArraySetAsSeries(rsi, true);
+
+   if(!TouchesEMABand(bars[1], ema20[1], ema50[1])) return false;
+   if(!(rsi[1] >= (100.0-RSIZoneHigh) && rsi[1] <= (100.0-RSIZoneLow) && rsi[1] < rsi[2])) return false;
+
+   double ll = DBL_MAX;
+   for(int i=2;i<2+BreakoutLookbackBars;i++) ll = MathMin(ll, bars[i].low);
+   return (bars[1].close < ll);
+}
+
+void ManagePosition()
+{
+   if(!PositionSelect(_Symbol)) return;
+   if((int)PositionGetInteger(POSITION_MAGIC) != MagicNumber) return;
+
+   long type = PositionGetInteger(POSITION_TYPE);
+   double sl = PositionGetDouble(POSITION_SL);
+   double tp = PositionGetDouble(POSITION_TP);
+
+   MqlRates bars[];
+   if(CopyRates(_Symbol, PERIOD_M5, 0, 3, bars) < 3) return;
+   ArraySetAsSeries(bars, true);
+
+   double ema20[3];
+   if(CopyBuffer(hEMA20, 0, 0, 3, ema20) < 3) return;
+   ArraySetAsSeries(ema20, true);
+
+   if(type == POSITION_TYPE_BUY)
+   {
+      if(bars[1].close < ema20[1] && bars[2].close >= ema20[2])
+      {
+         trade.PositionClose(_Symbol);
+         return;
+      }
+
+      double fract;
+      if(FindLatestFractalLow(fract))
+      {
+         double newSL = fract - SlBufferPoints * _Point;
+         double bid = SymbolInfoDouble(_Symbol, SYMBOL_BID);
+         if(newSL > sl && newSL < bid)
+            trade.PositionModify(_Symbol, NormalizeDouble(newSL, _Digits), tp);
+      }
+   }
+   else if(type == POSITION_TYPE_SELL)
+   {
+      if(bars[1].close > ema20[1] && bars[2].close <= ema20[2])
+      {
+         trade.PositionClose(_Symbol);
+         return;
+      }
+
+      double fract;
+      if(FindLatestFractalHigh(fract))
+      {
+         double ask = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+         double spreadPts = (ask - SymbolInfoDouble(_Symbol, SYMBOL_BID)) / _Point;
+         double newSL = fract + (spreadPts + SlBufferPoints) * _Point;
+         if((sl == 0.0 || newSL < sl) && newSL > ask)
+            trade.PositionModify(_Symbol, NormalizeDouble(newSL, _Digits), tp);
+      }
+   }
+}
+
+int OnInit()
+{
+   if(_Period != PERIOD_M5) return(INIT_FAILED);
+
+   trade.SetExpertMagicNumber(MagicNumber);
+   PEAK_BALANCE_KEY = "DirectionalPullbackEA_peak_" + (string)AccountInfoInteger(ACCOUNT_LOGIN);
+   UpdatePeakBalance();
+
+   hEMA20 = iMA(_Symbol, PERIOD_M5, FastEMAPeriod, 0, MODE_EMA, PRICE_CLOSE);
+   hEMA50 = iMA(_Symbol, PERIOD_M5, SlowEMAPeriod, 0, MODE_EMA, PRICE_CLOSE);
+   hRSI   = iRSI(_Symbol, PERIOD_M5, RSIPeriod, PRICE_CLOSE);
+
+   if(hEMA20==INVALID_HANDLE || hEMA50==INVALID_HANDLE || hRSI==INVALID_HANDLE)
+      return(INIT_FAILED);
+
+   return(INIT_SUCCEEDED);
+}
+
+void OnDeinit(const int reason)
+{
+   if(hEMA20!=INVALID_HANDLE) IndicatorRelease(hEMA20);
+   if(hEMA50!=INVALID_HANDLE) IndicatorRelease(hEMA50);
+   if(hRSI!=INVALID_HANDLE) IndicatorRelease(hRSI);
+}
+
+void OnTick()
+{
+   if(_Period != PERIOD_M5) return;
+   if(!IsAllowedSymbol()) return;
+   if(!InSession()) return;
+
+   double ask = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+   double bid = SymbolInfoDouble(_Symbol, SYMBOL_BID);
+   double spreadPts = (ask - bid) / _Point;
+   if(spreadPts > MaxSpreadPoints) return;
+
+   UpdatePeakBalance();
+
+   if(IsNewBar()) ManagePosition();
+   if(HasOpenPositionForSymbol()) return;
+
+   if(DirectionMode == LongOnly || DirectionMode == Both)
+   {
+      if(BuySignal())
+      {
+         double fract;
+         if(!FindLatestFractalLow(fract)) return;
+         double sl = fract - SlBufferPoints * _Point;
+         double lot = CalcLotByRisk(ask - sl);
+         if(lot > 0.0 && sl < ask)
+            trade.Buy(lot, _Symbol, 0.0, NormalizeDouble(sl, _Digits), 0.0, "DirPullbackEA");
+      }
+   }
+
+   if(DirectionMode == ShortOnly || DirectionMode == Both)
+   {
+      if(SellSignal())
+      {
+         double fract;
+         if(!FindLatestFractalHigh(fract)) return;
+         double sl = fract + (spreadPts + SlBufferPoints) * _Point;
+         double lot = CalcLotByRisk(sl - bid);
+         if(lot > 0.0 && sl > bid)
+            trade.Sell(lot, _Symbol, 0.0, NormalizeDouble(sl, _Digits), 0.0, "DirPullbackEA");
+      }
+   }
+}


### PR DESCRIPTION
### Motivation
- Resolve an MT4 compile error caused by non-portable `StringUpper` usage and ensure consistent symbol allowlist parsing in both MT4 and MT5 EAs.
- Improve runtime diagnostics and address compiler warnings by verifying return values from trade functions in the MT4 EA.
- Provide a small, portable string helper layer to avoid language-version-dependent behavior across MetaTrader environments.

### Description
- Added `ToUpperCopy` (uses `StringToUpper`) and `TrimCopy` helpers to both `experts/DirectionalPullbackEA.mq4` and `experts/DirectionalPullbackEA.mq5` and replaced prior `StringUpper`/trim patterns with these helpers.
- Switched allowlist parsing to use the new `TrimCopy` when splitting `AllowedSymbolsCSV` so symbol comparisons are robust.
- In the MT4 EA, added return-value checks and error `Print` logging for `OrderSend`, `OrderClose`, and `OrderModify` calls and wrapped entry `if` blocks to avoid single-line-if pitfalls.
- Kept MT5 implementation compatible (helper usage only) and left MT5 trading paths using `CTrade` unchanged except for the symbol-normalization helper.

### Testing
- Ran `git diff --cached --check` and repository pre-commit checks which passed with no whitespace/patch-format issues.
- Verified repository status and staged changes as part of the update cycle and ensured the modified files were included in the change set.
- Performed local source edits and basic grep/line inspections to confirm all `StringUpper` and trim occurrences were replaced and trade-result checks were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69843ba713c0832985e4920205ba1c69)